### PR TITLE
Updated sqlite version by updating package.json for the server and also updated the README.md to show affected change.

### DIFF
--- a/webservice/server/README.md
+++ b/webservice/server/README.md
@@ -5,7 +5,7 @@ Tested on Node versions 4.2.6 and 8.5.
 
 Get node.js and NPM up and running then...
 
-Install the Node.js dependencies (swagger-routes restify sqlite3 uuid4 mosca):
+Install the Node.js dependencies (swagger-routes restify sqlite4 uuid4 mosca):
 ~~~~
 npm install
 ~~~~

--- a/webservice/server/README.md
+++ b/webservice/server/README.md
@@ -26,7 +26,7 @@ For testing or debugging the MQTT broker, if necessary, you can use:
  * [mqtt-spy](http://kamilfb.github.io/mqtt-spy/)
 
 ### User Database
-To edit the sqlite3 database that stores user profiles (./node-server/db/data.db) you can use sqlitebrowser:
+To edit the sqlite4 database that stores user profiles (./node-server/db/data.db) you can use sqlitebrowser:
 
     sudo apt update
     sudo apt install sqlitebrowser

--- a/webservice/server/package.json
+++ b/webservice/server/package.json
@@ -20,7 +20,7 @@
     "mosca": "^2.5.2",
     "restify": "^5.2.0",
     "restify-cors-middleware": "^1.0.1",
-    "sqlite3": "^3.1.11",
+    "sqlite4": "^4.0.2",
     "swagger-routes": "^1.6.0",
     "uuid4": "^1.0.0"
   }


### PR DESCRIPTION
The sqlite3 version returns unnecessary logs whiile installing because of a bug in that version. Issue can be find at https://github.com/mapbox/node-sqlite3/issues/612 and the solution is to upgrade to sqlite 4.0.2
After updating the sqlite version, there's need to update the README.md for the server.